### PR TITLE
Specify behavior when re-enabling auditing after schema changes

### DIFF
--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -65,6 +65,12 @@ def _track_table(
 def track_changes(db: sqlite3.Connection, history_table: str = HISTORY_TABLE) -> None:
     events = ["INSERT", "UPDATE", "DELETE"]
     with db:
+        if db.in_transaction:
+            msg = (
+                "Cannot enable auditing: this connection already has a "
+                "transaction in progress. COMMIT or ROLLBACK and try again."
+            )
+            raise sqlite3.ProgrammingError(msg)
         db.execute("BEGIN")
         db.execute(_gen_audit_table_ddl(history_table))
         tables = db.execute(

--- a/audite/test_audite.py
+++ b/audite/test_audite.py
@@ -126,10 +126,12 @@ def test_it_follows_schema_changes(db: sqlite3.Connection) -> None:
         db.execute("INSERT INTO post (content) VALUES ('before')")
         db.execute("ALTER TABLE post ADD COLUMN version INTEGER")
         db.execute("ALTER TABLE post RENAME COLUMN content TO body")
+        db.execute("CREATE TABLE not_yet_audited (value TEXT PRIMARY KEY)")
 
     with db:
         track_changes(db)
         db.execute("INSERT INTO post (body, version) VALUES ('after', 2)")
+        db.execute("INSERT INTO not_yet_audited (value) VALUES ('audited now')")
 
     history = list(db.execute("SELECT payload FROM _audite_history"))
     changes = [json.loads(row[0]) for row in history]
@@ -140,6 +142,7 @@ def test_it_follows_schema_changes(db: sqlite3.Connection) -> None:
     assert "content" not in changes[1]
     assert changes[1]["body"] == "after"
     assert changes[1]["version"] == 2
+    assert changes[2]["value"] == "audited now"
 
 
 def test_it_raises_when_trying_to_enable_auditing_in_an_already_open_tx(


### PR DESCRIPTION
This PR adds tests that describe how to audit new columns after you've changed the schema of an existing table or added a new table.