### PR TITLE
Split 'payload' column into 'newval' and 'oldval'

### DIFF
--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -29,7 +29,7 @@ def _gen_audit_table_ddl(table_name: str) -> str:
     return ddl
 
 
-def _json_object_sql(ref: t.Literal["OLD", "NEW"], cols: list[str]) -> str:
+def _json_object_sql(ref: t.Literal["OLD", "NEW"], cols: t.List[str]) -> str:
     """
     Approximates pg's 'row_to_json()' function by inspecting the table schema
     and building a json_object(label1, value1, label2, value2...) expression.
@@ -41,7 +41,7 @@ def _json_object_sql(ref: t.Literal["OLD", "NEW"], cols: list[str]) -> str:
     return sql
 
 
-def _build_newval_oldval_sql(cols: list[str], event: str) -> tuple[str, str]:
+def _build_newval_oldval_sql(cols: t.List[str], event: str) -> t.Tuple[str, str]:
     if event == "DELETE":
         return "NULL", _json_object_sql("OLD", cols)
     elif event == "UPDATE":

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="audite",
-    version="0.1.0",
+    version="0.2.0",
     description="Instant data auditing for SQLite",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR makes a breaking schema change to Audite's history table. Instead of tracking the current value of the changed row in one `payload` column, we track its new and old values separately in columns called `newval` and `oldval`.