### PR TITLE
Support auditing only specified tables

### DIFF
--- a/audite/test_auditor.py
+++ b/audite/test_auditor.py
@@ -123,7 +123,16 @@ def test_it_can_customize_table_name(db: sqlite3.Connection) -> None:
 
 
 def test_it_can_audit_only_specified_tables(db: sqlite3.Connection) -> None:
-    pass
+    track_changes(db, tables=["post"])
+    db.execute("INSERT INTO post (content) VALUES ('first')")
+    db.execute(
+        """
+        INSERT INTO comment (id, post_id, content) VALUES
+        ('comment.1', 1, 'first comment')
+        """
+    )
+    history = list(db.execute("SELECT tblname FROM _audite_history"))
+    assert history == [("post",)]
 
 
 def test_it_follows_schema_changes(db: sqlite3.Connection) -> None:


### PR DESCRIPTION
This PR adds a `tables` keyword arg to `auditor.track_changes`, so that you can decide which tables to track. (Previously audite always tracked every table except its own and the internal `sqlite_` tables.)