### PR TITLE
Follow the CloudEvents spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
 # Audite
-Instant data auditing for SQLite
+
+Audite uses SQLite triggers to automatically log all INSERT, UPDATE, and
+DELETE operations on a target SQLite database. It gives you a comprehensive,
+totally-ordered history of all changes to your data, without touching your
+application code or running an extra process.
+
+## Example
+
+Let's create `shop.db`, a database with the following schema:
+
+```sh
+sqlite3 shop.db "CREATE TABLE IF NOT EXISTS products (name TEXT PRIMARY KEY, price REAL NOT NULL);"
+```
+
+### Step 1: Enable the audite triggers
+You only need to do this once per database/schema:
+
+```sh
+python3 -m audite shop.db
+```
+It's safe to run audite multiple times, for example as part of your app's
+startup script. When the database schema hasn't changed, then re-running
+audite is effectively a noop; when the schema _has_ changed, then re-running
+audite will ensure that incoming change events use your latest schema.
+
+### Step 2: Create, Update, and Delete some data
+This example uses the `sqlite3` CLI to make changes, but any interface into
+your SQLite database should work.
+
+Add some products:
+```sh
+sqlite3 shop.db "INSERT INTO products (name, price) VALUES ('notebook', 2.99), ('pen', 0.25)"
+
+Adjust for inflation:
+```sh
+sqlite3 shop.db "UPDATE products SET price = ROUND(price * 1.1, 2)"
+```
+
+Pens have gone out of stock:
+```sh
+sqlite3 shop.db "DELETE FROM products WHERE name = 'pen'"
+```
+
+### Step 3: Query the event history
+
+```sh
+sqlite3 shop.db "SELECT * FROM audite_history ORDER BY id"
+```
+
+You should get back something like:
+```
+id  source    subject   type              time        specversion  data
+--  --------  --------  ----------------  ----------  -----------  -------------------------------------------------------------------------------
+1   products  notebook  products.created  1669046846  1.0          {"new":{"price":2.99,"name":"notebook"}}
+2   products  pen       products.created  1669046846  1.0          {"new":{"price":0.25,"name":"pen"}}
+3   products  notebook  products.updated  1669046866  1.0          {"new":{"price":3.29,"name":"notebook"},"old":{"price":2.99,"name":"notebook"}}
+4   products  pen       products.updated  1669046866  1.0          {"new":{"price":0.28,"name":"pen"},"old":{"price":0.25,"name":"pen"}}
+5   products  pen       products.deleted  1669046885  1.0          {"old":{"price":0.28,"name":"pen"}}
+```
+
+#### Event Schema
+- `id` uniquely identifies the event.
+- `source` is name of the database table that changed.
+- `subject` is the primary key of the database row that changed.
+- `type` describes the type of change: `*.created`, `*.updated`, or `*.deleted`.
+- `time` is the unix epoch timestamp when the change was committed.
+- `specversion` is the verion of the [CloudEvents spec](https://github.com/cloudevents/spec) in use, currently `1.0`.
+- `data` is a JSON snapshot of the row that changed. The `data.new` object holds the post-change values and is present for `*.created` and `*.updated` events. The `data.old` object holds pre-change values is present for `*.updated` and `*.deleted` events.
+
+The event schema follows the [CloudEvents
+spec](https://github.com/cloudevents/spec) with two exceptions: `id` and `time`
+are integers instead of strings so that SQLite can store and sort them
+efficiently. To conform exactly to the [CloudEvents JSON
+spec](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md#23-examples),
+you can query the `audite_cloudevents` view instead of the underlying
+`audite_history` table:
+
+```sh
+sqlite3 shop.db "SELECT id, cloudevent FROM audite_cloudevents ORDER BY id"
+```

--- a/audite/__main__.py
+++ b/audite/__main__.py
@@ -1,1 +1,18 @@
-print("audite")
+import argparse
+import sqlite3
+
+from .auditor import track_changes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("db_path")
+    args = parser.parse_args()
+
+    db = sqlite3.connect(args.db_path)
+    track_changes(db)
+    print(f"auditing enabled for {args.db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -16,7 +16,7 @@ class Event(t.NamedTuple):
     data: str
 
 
-def _gen_audit_table_ddl() -> list[str]:
+def _gen_ddl() -> list[str]:
     table_ddl = f"""
     CREATE TABLE IF NOT EXISTS "{TABLE_NAME}" (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -32,6 +32,7 @@ def _gen_audit_table_ddl() -> list[str]:
     CREATE VIEW IF NOT EXISTS "{VIEW_NAME}" AS
     SELECT *, json_object(
         'id', CAST(id AS TEXT),
+        'sequence', printf('%020d', id),
         'source', source,
         'subject', subject,
         'type', type,
@@ -148,7 +149,7 @@ def track_changes(
 
         db.execute("BEGIN")
 
-        for statement in _gen_audit_table_ddl():
+        for statement in _gen_ddl():
             db.execute(statement)
 
         if tables is None:

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -60,14 +60,14 @@ def _json_object_sql(ref: t.Literal["OLD", "NEW"], cols: t.List[str]) -> str:
 
 def _build_newval_oldval_sql(cols: t.List[str], event: str) -> str:
     if event == "DELETE":
-        return f"json_object('values', {_json_object_sql('OLD', cols)})"
+        return f"json_object('row', {_json_object_sql('OLD', cols)})"
     elif event == "UPDATE":
         return (
-            f"json_object('values', {_json_object_sql('NEW', cols)}, "
-            f"'oldvalues', {_json_object_sql('OLD', cols)})"
+            f"json_object('row', {_json_object_sql('NEW', cols)}, "
+            f"'oldrow', {_json_object_sql('OLD', cols)})"
         )
     elif event == "INSERT":
-        return f"json_object('values', {_json_object_sql('NEW', cols)})"
+        return f"json_object('row', {_json_object_sql('NEW', cols)})"
 
     raise ValueError(f"{event} is not one of INSERT, UPDATE, or DELETE")
 

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -10,6 +10,7 @@ class Event(t.NamedTuple):
     subject: str
     type: str
     time: str
+    specversion: str
     data: str
 
 
@@ -20,8 +21,9 @@ def _gen_audit_table_ddl(table_name: str) -> str:
         source TEXT NOT NULL,
         subject TEXT NOT NULL,
         type TEXT NOT NULL,
-        data JSON,
-        time TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S+00:00'))
+        time TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S+00:00')),
+        specversion TEXT NOT NULL,
+        data JSON
     );
     """
     return ddl
@@ -86,8 +88,9 @@ def _track_table(
     statement = f"""
     CREATE TRIGGER "{trigger_name}" AFTER {event} ON "{table}"
     BEGIN
-        INSERT INTO "{history_table}" ("source", "subject", "type", "data")
-        VALUES ('{table}', {rowname}, '{event_type}', {data});
+        INSERT INTO "{history_table}"
+        ("source", "subject", "type", "specversion", "data")
+        VALUES ('{table}', {rowname}, '{event_type}', '1.0', {data});
     END
     """
     cursor.execute(statement)

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -4,7 +4,7 @@ import typing as t
 HISTORY_TABLE = "_audite_history"
 
 
-class Record(t.NamedTuple):
+class Event(t.NamedTuple):
     id: int
     source: str
     subject: str

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -2,7 +2,7 @@ import sqlite3
 import typing as t
 
 CLOUDEVENT_SPECVERSION = "1.0"
-TABLE_NAME = "audite_changelog"
+TABLE_NAME = "audite_history"
 VIEW_NAME = "audite_cloudevents"
 
 
@@ -74,7 +74,7 @@ def _build_newval_oldval_sql(cols: t.List[str], event: str) -> str:
 def _track_table(db: sqlite3.Connection, table: str, event: str) -> None:
     cursor = db.cursor()
     record_ref = "OLD" if event == "DELETE" else "NEW"
-    trigger_name = f"_audite_audit_{table}_{event.lower()}_trigger"
+    trigger_name = f"audite_audit_{table}_{event.lower()}_trigger"
 
     cursor.execute(f"DROP TRIGGER IF exists {trigger_name}")
 
@@ -114,7 +114,7 @@ def _track_table(db: sqlite3.Connection, table: str, event: str) -> None:
 
 def _create_indices(db: sqlite3.Connection) -> None:
     # Support querying the history of a particular subject:
-    # SELECT * from audite_events WHERE (source, subject) = ('post', '123')
+    # SELECT * from audite_history WHERE (source, subject) = ('post', '123')
     db.execute(
         f"""
         CREATE INDEX IF NOT EXISTS "{TABLE_NAME}_source_subject_id_idx"
@@ -123,7 +123,7 @@ def _create_indices(db: sqlite3.Connection) -> None:
     )
 
     # Support querying by timestamp:
-    # SELECT * from _audite_history WHERE time > '2022-11-19'
+    # SELECT * from audite_history WHERE time > 1668982601
     db.execute(
         f"""
         CREATE INDEX IF NOT EXISTS "{TABLE_NAME}_time_id_idx"

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -60,14 +60,14 @@ def _json_object_sql(ref: t.Literal["OLD", "NEW"], cols: t.List[str]) -> str:
 
 def _build_newval_oldval_sql(cols: t.List[str], event: str) -> str:
     if event == "DELETE":
-        return f"json_object('row', {_json_object_sql('OLD', cols)})"
+        return f"json_object('old', {_json_object_sql('OLD', cols)})"
     elif event == "UPDATE":
         return (
-            f"json_object('row', {_json_object_sql('NEW', cols)}, "
-            f"'oldrow', {_json_object_sql('OLD', cols)})"
+            f"json_object('new', {_json_object_sql('NEW', cols)}, "
+            f"'old', {_json_object_sql('OLD', cols)})"
         )
     elif event == "INSERT":
-        return f"json_object('row', {_json_object_sql('NEW', cols)})"
+        return f"json_object('new', {_json_object_sql('NEW', cols)})"
 
     raise ValueError(f"{event} is not one of INSERT, UPDATE, or DELETE")
 

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -16,7 +16,7 @@ class Event(t.NamedTuple):
     data: str
 
 
-def _gen_ddl() -> list[str]:
+def _gen_ddl() -> t.List[str]:
     table_ddl = f"""
     CREATE TABLE IF NOT EXISTS "{TABLE_NAME}" (
         id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/audite/auditor.py
+++ b/audite/auditor.py
@@ -158,10 +158,10 @@ def track_changes(
                 for row in db.execute(
                     """
                     SELECT tbl_name FROM sqlite_master
-                    WHERE type='table' AND tbl_name NOT LIKE 'sqlite%'
-                    AND tbl_name != :audite_table
-                    """,
-                    {"audite_table": TABLE_NAME},
+                    WHERE type='table'
+                    AND tbl_name NOT LIKE 'sqlite_%'
+                    AND tbl_name NOT LIKE 'audite_%'
+                    """
                 )
             ]
 

--- a/audite/test_auditor.py
+++ b/audite/test_auditor.py
@@ -48,7 +48,7 @@ def test_it_audits_insert_update_and_delete_on_all_tables_by_default(
         Event(*row)
         for row in db.execute(
             """
-            SELECT id, source, subject, type, time, data
+            SELECT id, source, subject, type, time, specversion, data
             from _audite_history ORDER BY id
             """
         )
@@ -215,12 +215,13 @@ def test_it_conforms_to_the_cloudevents_spec(db: sqlite3.Connection) -> None:
                 "subject": row[2],
                 "type": row[3],
                 "time": row[4],
+                "specversion": row[5],
             },
-            data=json.loads(row[5]),
+            data=json.loads(row[6]),
         )
         for row in db.execute(
             """
-            SELECT CAST(id AS TEXT) id, source, subject, type, time, data
+            SELECT CAST(id AS TEXT) id, source, subject, type, time, specversion, data
             from _audite_history ORDER BY id
             """
         )

--- a/audite/test_auditor.py
+++ b/audite/test_auditor.py
@@ -90,14 +90,22 @@ def test_it_supports_compound_primary_keys(db: sqlite3.Connection) -> None:
         """
     )
     track_changes(db)
+
     db.execute(
         """
         INSERT INTO "namespace.with_compound_pk" (this, that, other, etc)
         VALUES ('hello','world', 1, 3.14159)
         """
     )
-    history = list(db.execute("SELECT subject FROM _audite_history"))
-    assert history == [("hello:world:1:3.14159",)]
+    history = list(db.execute("SELECT source, type, subject FROM _audite_history"))
+
+    assert history == [
+        (
+            "namespace.with_compound_pk",
+            "namespace.with_compound_pk.created",
+            "hello:world:1:3.14159",
+        )
+    ]
 
 
 def test_it_does_not_miss_messages_when_recreating_tables_and_triggers(

--- a/audite/test_auditor.py
+++ b/audite/test_auditor.py
@@ -64,15 +64,15 @@ def test_it_audits_insert_update_and_delete_on_all_tables_by_default(
     ]
 
     first_post_json = json.loads(history[0].data or "{}")
-    assert first_post_json["row"]["id"] == 1
-    assert first_post_json["row"]["content"] == "first"
+    assert first_post_json["new"]["id"] == 1
+    assert first_post_json["new"]["content"] == "first"
 
     last_post_json = json.loads(history[-1].data or "{}")
-    assert last_post_json["row"]["content"] == "second"
+    assert last_post_json["old"]["content"] == "second"
 
     update = [row for row in history if row.type == "comment.updated"][0]
-    assert json.loads(update.data or "")["row"]["content"] == "revised"
-    assert json.loads(update.data or "")["oldrow"]["content"] == "first comment"
+    assert json.loads(update.data or "")["new"]["content"] == "revised"
+    assert json.loads(update.data or "")["old"]["content"] == "first comment"
 
 
 def test_it_supports_compound_primary_keys(db: sqlite3.Connection) -> None:
@@ -155,7 +155,7 @@ def test_it_follows_schema_changes(db: sqlite3.Connection) -> None:
         db.execute("INSERT INTO not_yet_audited (value) VALUES ('audited now')")
 
     events = list(db.execute("SELECT data FROM audite_history"))
-    changes = [json.loads(e[0] or "{}")["row"] for e in events]
+    changes = [json.loads(e[0] or "{}")["new"] for e in events]
 
     assert changes[0]["content"] == "before"
     assert "version" not in changes[0]
@@ -209,7 +209,7 @@ def test_it_conforms_to_the_cloudevents_spec(db: sqlite3.Connection) -> None:
     assert events[0]["subject"] == "1"
     assert events[0]["specversion"] == "1.0"
     assert events[0]["type"] == "post.created"
-    assert events[0].data["row"]["content"] == "p1"
+    assert events[0].data["new"]["content"] == "p1"
 
     # filtering by id with a string should work
     q = "SELECT cloudevent FROM audite_cloudevents WHERE id > :offset"

--- a/audite/test_auditor.py
+++ b/audite/test_auditor.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import pathlib
 import sqlite3
@@ -5,6 +6,7 @@ import subprocess
 import tempfile
 import typing as t
 
+import cloudevents.http  # type: ignore
 import pytest
 
 from .auditor import Record, track_changes
@@ -46,31 +48,39 @@ def test_it_audits_insert_update_and_delete_on_all_tables_by_default(
         Record(*row)
         for row in db.execute(
             """
-            SELECT position, tblname, rowname, operation, changed_at, newval, oldval
-            from _audite_history ORDER BY position
+            SELECT id, source, subject, type, time, data
+            from _audite_history ORDER BY id
             """
         )
     ]
-    operations = [row.operation for row in history]
-    assert operations == ["I", "I", "I", "I", "U", "D"]
+    operations = [row.type for row in history]
+    assert operations == [
+        "post.created",
+        "post.created",
+        "comment.created",
+        "comment.created",
+        "comment.updated",
+        "post.deleted",
+    ]
 
-    first_post_json = json.loads(history[0].newval or "{}")
-    assert first_post_json["id"] == 1
-    assert first_post_json["content"] == "first"
+    first_post_json = json.loads(history[0].data or "{}")
+    assert first_post_json["values"]["id"] == 1
+    assert first_post_json["values"]["content"] == "first"
 
-    deleted_post_oldval = json.loads(history[-1].oldval or "{}")
-    assert deleted_post_oldval["content"] == "second"
-    assert history[-1].newval is None
+    last_post_json = json.loads(history[-1].data or "{}")
+    assert last_post_json["values"]["content"] == "second"
 
-    update = [row for row in history if row.operation == "U"][0]
-    assert json.loads(update.oldval or "")["content"] == "first comment"
-    assert json.loads(update.newval or "")["content"] == "revised"
+    update = [row for row in history if row.type == "comment.updated"][0]
+    assert json.loads(update.data or "")["values"]["content"] == "revised"
+    assert json.loads(update.data or "")["oldvalues"]["content"] == "first comment"
+
+    assert datetime.datetime.fromisoformat(history[0].time)
 
 
 def test_it_supports_compound_primary_keys(db: sqlite3.Connection) -> None:
     db.execute(
         """
-        CREATE TABLE compound (
+        CREATE TABLE "namespace.with_compound_pk" (
             this TEXT,
             that TEXT,
             other INTEGER,
@@ -82,12 +92,12 @@ def test_it_supports_compound_primary_keys(db: sqlite3.Connection) -> None:
     track_changes(db)
     db.execute(
         """
-        INSERT INTO compound (this, that, other, etc)
+        INSERT INTO "namespace.with_compound_pk" (this, that, other, etc)
         VALUES ('hello','world', 1, 3.14159)
         """
     )
-    history = list(db.execute("SELECT rowname FROM _audite_history"))
-    assert history == [("hello/world/1/3.14159",)]
+    history = list(db.execute("SELECT subject FROM _audite_history"))
+    assert history == [("hello:world:1:3.14159",)]
 
 
 def test_it_does_not_miss_messages_when_recreating_tables_and_triggers(
@@ -107,15 +117,15 @@ def test_it_audits_changes_from_external_processes(db: sqlite3.Connection) -> No
     args = ["python3", "-c", "\n".join(script)]
     subprocess.run(args, check=True)
 
-    history = list(db.execute("SELECT tblname, rowname FROM _audite_history"))
+    history = list(db.execute("SELECT source, subject FROM _audite_history"))
     assert history == [("post", "1")]
 
 
 def test_it_can_customize_table_name(db: sqlite3.Connection) -> None:
-    track_changes(db, history_table="custom_history")
+    track_changes(db, history_table="custom.history")
     db.execute("INSERT INTO post (content) VALUES ('first'), ('second')")
 
-    history = list(db.execute("SELECT position FROM custom_history"))
+    history = list(db.execute('SELECT id FROM "custom.history"'))
     assert history == [(1,), (2,)]
 
     with pytest.raises(sqlite3.OperationalError):
@@ -131,7 +141,7 @@ def test_it_can_audit_only_specified_tables(db: sqlite3.Connection) -> None:
         ('comment.1', 1, 'first comment')
         """
     )
-    history = list(db.execute("SELECT tblname FROM _audite_history"))
+    history = list(db.execute("SELECT source FROM _audite_history"))
     assert history == [("post",)]
 
 
@@ -149,8 +159,8 @@ def test_it_follows_schema_changes(db: sqlite3.Connection) -> None:
         db.execute("INSERT INTO post (body, version) VALUES ('after', 2)")
         db.execute("INSERT INTO not_yet_audited (value) VALUES ('audited now')")
 
-    history = list(db.execute("SELECT newval FROM _audite_history"))
-    changes = [json.loads(row[0] or "{}") for row in history]
+    history = list(db.execute("SELECT data FROM _audite_history"))
+    changes = [json.loads(row[0] or "{}")["values"] for row in history]
 
     assert changes[0]["content"] == "before"
     assert "version" not in changes[0]
@@ -172,7 +182,7 @@ def test_it_raises_when_trying_to_enable_auditing_in_an_already_open_tx(
 
 def test_it_adds_indices_by_default(db: sqlite3.Connection) -> None:
     track_changes(db)
-    idx_name = "_audite_history_tblname_rowname_position_idx"
+    idx_name = "_audite_history_source_subject_id_idx"
     q = f"SELECT name FROM sqlite_master WHERE type='index' AND name = '{idx_name}'"
 
     idx = db.execute(q).fetchone()[0]
@@ -183,3 +193,33 @@ def test_it_adds_indices_by_default(db: sqlite3.Connection) -> None:
 
     idx = db.execute(q).fetchone()
     assert idx is None
+
+
+def test_it_conforms_to_the_cloudevents_spec(db: sqlite3.Connection) -> None:
+    track_changes(db)
+    db.execute("INSERT INTO post (content) VALUES ('p1')")
+
+    events = [
+        cloudevents.http.CloudEvent(
+            attributes={
+                "id": row[0],
+                "source": row[1],
+                "subject": row[2],
+                "type": row[3],
+                "time": row[4],
+            },
+            data=json.loads(row[5]),
+        )
+        for row in db.execute(
+            """
+            SELECT CAST(id AS TEXT) id, source, subject, type, time, data
+            from _audite_history ORDER BY id
+            """
+        )
+    ]
+    assert events[0]["id"] == "1"
+    assert events[0]["source"] == "post"
+    assert events[0]["subject"] == "1"
+    assert events[0]["specversion"] == "1.0"
+    assert events[0]["type"] == "post.created"
+    assert events[0].data["values"]["content"] == "p1"

--- a/audite/test_auditor.py
+++ b/audite/test_auditor.py
@@ -9,7 +9,7 @@ import typing as t
 import cloudevents.http  # type: ignore
 import pytest
 
-from .auditor import Record, track_changes
+from .auditor import Event, track_changes
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def test_it_audits_insert_update_and_delete_on_all_tables_by_default(
     db.execute("UPDATE comment SET content = 'revised' WHERE id = 'comment.1'")
     db.execute("DELETE from post WHERE id = 2")
     history = [
-        Record(*row)
+        Event(*row)
         for row in db.execute(
             """
             SELECT id, source, subject, type, time, data

--- a/audite/test_auditor.py
+++ b/audite/test_auditor.py
@@ -199,6 +199,9 @@ def test_it_conforms_to_the_cloudevents_spec(db: sqlite3.Connection) -> None:
 
     # id should be a string
     assert events[0]["id"] == "1"
+    # sequence should be the same 'number' as id but with enough zero-padding
+    # to account for all the largest 64-bit unsigned integer
+    assert events[0]["sequence"] == "00000000000000000001"
     # time should be parsable as ISO-8601
     assert datetime.datetime.fromisoformat(events[0]["time"])
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+cloudevents==1.7.0
 black==22.10.0
 flake8==5.0.4
 isort==5.10.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="audite",
-    version="0.2.0",
+    version="0.3.0",
     description="Instant data auditing for SQLite",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR changes the event schema to follow the [CloudEvents spec](https://github.com/cloudevents), so that systems using CloudEvents can more easily subscribe to an audite change feed.